### PR TITLE
Group equipment at configuration update

### DIFF
--- a/core/ajax/enphasesecur.ajax.php
+++ b/core/ajax/enphasesecur.ajax.php
@@ -29,7 +29,13 @@ try {
   */
     ajax::init();
 
-
+    $action =  init('action');
+    switch($action) {
+      case 'PostSaveConfiguration':
+        enphasesecur::creationmaj();
+        ajax::success();
+        break;
+    }
 
     throw new Exception(__('Aucune méthode correspondante à', __FILE__) . ' : ' . init('action'));
     /*     * *********Catch exeption*************** */

--- a/desktop/js/enphasesecur.js
+++ b/desktop/js/enphasesecur.js
@@ -98,3 +98,27 @@ function addCmdToTable(_cmd) {
     }
   })
 }
+
+/** Post save configuration function */
+function enphasesecur_postSaveConfiguration() {
+  $.ajax({
+    type: "POST",
+    url: 'plugins/enphasesecur/core/ajax/enphasesecur.ajax.php',
+    data: {
+        action: "PostSaveConfiguration",
+    },
+    dataType: 'json',
+    error: function (request, status, error) {
+      handleAjaxError(request, status, error, $('#div_alert'));
+      $('#div_alert').showAlert({message: '{{Erreur de sauvegarde.}}', level: 'error'});
+    },
+    success: function (data) {
+      if (data.state == 'ok') {
+        $('#div_alert').showAlert({message: '{{Configuration mise à jour!}}', level: 'success'});
+        return;
+      }else{
+        $('#div_alert').showAlert({message: '{{Erreur Mise à jour configuration}}', level: 'error'});
+      }
+    }
+  })
+}


### PR DESCRIPTION
Currently the group creation is only launched at deamon start.
The purpose of this PR is to create these groups at configuration save.